### PR TITLE
Update Hyperlink in: Extract CSV files and Tables from Websites.ipynb 

### DIFF
--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -817,7 +817,7 @@
    "id": "dental-cradle",
    "metadata": {},
    "source": [
-    "Target Website: https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320) "
+         [Target Website](https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320))
    ]
   },
   {

--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -812,14 +812,14 @@
     "# Read HTML"
    ]
   },
-  {
+{
    "cell_type": "markdown",
    "id": "dental-cradle",
    "metadata": {},
    "source": [
-       "Target Website: [https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)](https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320))"
+       "Target Website: [https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)](https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320%29)"
    ]
-   },
+},
   {
    "cell_type": "code",
    "execution_count": 6,

--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -817,8 +817,7 @@
    "id": "dental-cradle",
    "metadata": {},
    "source": [
-         [Target Website](https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320))
-   ]
+               "Target Website: https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)"
   },
   {
    "cell_type": "code",

--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -817,9 +817,9 @@
    "id": "dental-cradle",
    "metadata": {},
    "source": [
-               "Target Website: https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)"
-             ]
-  },
+       "Target Website: [https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)](https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320))"
+   ]
+   },
   {
    "cell_type": "code",
    "execution_count": 6,

--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -817,7 +817,7 @@
    "id": "dental-cradle",
    "metadata": {},
    "source": [
-       "Target Website: [https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)](https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320%29)"
+       "Target Website: (https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320%29)"
    ]
 },
   {

--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -818,6 +818,7 @@
    "metadata": {},
    "source": [
                "Target Website: https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)"
+             ]
   },
   {
    "cell_type": "code",

--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -817,7 +817,7 @@
    "id": "dental-cradle",
    "metadata": {},
    "source": [
-    "Target Website: https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320)"
+    "Target Website: https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320) "
    ]
   },
   {

--- a/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
+++ b/1.Table Extraction/Extract CSV files and Tables from Websites.ipynb
@@ -817,7 +817,7 @@
    "id": "dental-cradle",
    "metadata": {},
    "source": [
-       "Target Website: (https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_(seasons_1%E2%80%9320%29)"
+       "Target Website: https://en.wikipedia.org/wiki/List_of_The_Simpsons_episodes_%28seasons_1%E2%80%9320%29"
    ]
 },
   {


### PR DESCRIPTION
When clicking the hyperlink of the Simpsons episode wiki, you land on an error page.

I fixed the opening and closing brackets of the link to make it markdown readable

Ref:

https://github.com/thepycoach/automation/blob/main/1.Table%20Extraction/Extract%20CSV%20files%20and%20Tables%20from%20Websites.ipynb